### PR TITLE
update devcontainer base images to newer versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,13 @@ jobs:
 
     strategy:
       matrix:
-        image: ["typescript-node", "universal"]
+        include:
+          - image: "typescript-node"
+            tag: "22"
+          - image: "typescript-node"
+            tag: "24"
+          - image: "universal"
+            tag: "4.1.0-noble"
 
     steps:
       - name: Checkout
@@ -33,6 +39,8 @@ jobs:
         with:
           subFolder: ${{ matrix.image }}
           imageName: ghcr.io/codesandbox/devcontainers/${{ matrix.image }}
-          imageTag: latest,0.5
+          imageTag: ${{ matrix.tag }}
           cacheFrom: ghcr.io/codesandbox/devcontainers/${{ matrix.image }}
           push: always
+        env:
+          TAG: ${{ matrix.tag }}

--- a/typescript-node/.devcontainer/Dockerfile
+++ b/typescript-node/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG TAG=24
+FROM mcr.microsoft.com/devcontainers/typescript-node:${TAG}

--- a/typescript-node/.devcontainer/devcontainer.json
+++ b/typescript-node/.devcontainer/devcontainer.json
@@ -1,6 +1,12 @@
 {
     "name": "CodeSandbox Typescript Node.js",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+    "build": {
+        "context": ".",
+        "dockerfile": "Dockerfile",
+        "args": {
+            "TAG": "${localEnv:TAG}"
+        }
+    },
     "features": {
         "ghcr.io/codesandbox/devcontainer-features/codesandbox:0.1.4": {}
     },

--- a/universal/.devcontainer/Dockerfile
+++ b/universal/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/devcontainers/universal:2-focal
+ARG TAG=4.1.0-noble
+FROM mcr.microsoft.com/devcontainers/universal:${TAG}
 
 USER root
 

--- a/universal/.devcontainer/devcontainer.json
+++ b/universal/.devcontainer/devcontainer.json
@@ -2,7 +2,10 @@
     "name": "CodeSandbox Universal",
     "build": {
         "context": ".",
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "args": {
+            "TAG": "${localEnv:TAG}"
+        }
     },
     "features": {
         "ghcr.io/codesandbox/devcontainer-features/codesandbox:0.1.4": {}


### PR DESCRIPTION
With this PR we build images for 
- universal:4.1.0-noble
- typescript-node:24
- typescript-node:22