### PR TITLE
revert universal image to older version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - image: "typescript-node"
             tag: "24"
           - image: "universal"
-            tag: "4.1.0-noble"
+            tag: "2.0.6-focal"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR reverts universal image to older version as the newer versions do not seem to exist in the mcr registry